### PR TITLE
Fixes running under CCTweaks

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -106,7 +106,7 @@ local assetUrl = assert(release.assets and release.assets[1] and release.assets[
 print("Got JSON")
 local zipResponse = assert(http.get(assetUrl, {["Accept"]="application/octet-stream"}))
 assert(zipResponse.getResponseCode() == 200 or zipResponse.getResponseCode() == 302, "Failed zip response")
-local base64Str = zipResponse.readAll()
+local base64Str = zipResponse.readAll():gsub("\n", "")
 
 print("Decoding base64")
 sleep(0)

--- a/lib/zip
+++ b/lib/zip
@@ -1022,6 +1022,7 @@ function open(fileHandle)
     for b in fileHandle.read do
         table.insert(data, b)
     end
+    fileHandle.close()
 
     cursor = #data - 3
     repeat


### PR DESCRIPTION
The `http` API provides the entire contents of the file, including the trailing new line: but the decoder isn't expecting that. This fixes this problem.

Also closes a stray file handle which wasn't closed: CCTweaks has an optional upper bound on open file handles.
